### PR TITLE
Update bmi08a.c: fix accelerometer self-test

### DIFF
--- a/bmi08a.c
+++ b/bmi08a.c
@@ -2425,9 +2425,9 @@ static int8_t validate_accel_self_test(const struct bmi08x_sensor_data *accel_po
     /*! Structure for difference of accel values in mg */
     struct bmi08a_selftest_delta_limit accel_data_diff_mg = { 0 };
 
-    accel_data_diff.x = (uint16_t) (BMI08X_ABS(accel_pos->x) + BMI08X_ABS(accel_neg->x));
-    accel_data_diff.y = (uint16_t) (BMI08X_ABS(accel_pos->y) + BMI08X_ABS(accel_neg->y));
-    accel_data_diff.z = (uint16_t) (BMI08X_ABS(accel_pos->z) + BMI08X_ABS(accel_neg->z));
+    accel_data_diff.x = (uint16_t) BMI08X_ABS(BMI08X_ABS(accel_pos->x) - BMI08X_ABS(accel_neg->x));
+    accel_data_diff.y = (uint16_t) BMI08X_ABS(BMI08X_ABS(accel_pos->y) - BMI08X_ABS(accel_neg->y));
+    accel_data_diff.z = (uint16_t) BMI08X_ABS(BMI08X_ABS(accel_pos->z) - BMI08X_ABS(accel_neg->z));
 
     if (variant == BMI085_VARIANT)
     {


### PR DESCRIPTION
Adding the absolute values of the readings together does not compute the difference.

I found that accel_pos readings are positive and accel_neg readings are negative, so it could be simplified to `accel_pos->x + accel_neg->x`, but taking the absolute value of the difference will work either way.