### PR TITLE
Add code block formatting to the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ This package contains Bosch Sensortec's BMI08X Sensor API.
 
 Update variant of bmi08x_dev to BMI085_VARIANT to use the BMI085 sensor feature
 
-```
+```c
  dev.variant = BMI085_VARIANT;
 ```
 
 Update variant of bmi08x_dev to BMI088_VARIANT to use the BMI085 sensor feature
 
-```
+```c
  dev.variant = BMI088_VARIANT;
 ```
 
 - User has to include _bmi08x.h_ in the code to call sensor APIs as shown below :
 
-```
+```c
  #include "bmi08x.h"
 ```
 
@@ -64,6 +64,7 @@ _variant_           | BMI085_VARIANT
 
 ##### _Initialize through SPI interface_
 
+```c
 int8_t rslt;
 
 uint8_t acc_dev_addr = 0;
@@ -91,9 +92,11 @@ rslt = bmi08a_init(&dev);
 /* To Initialize gyro sensor */
 
 rslt = bmi08g_init(&dev);
+```
 
 ##### _Initialize through I2C interface_
 
+```c
 /* I2C slave address depends on the hardware configuration for details please refer Data sheet */
 
 int8_t rslt;
@@ -124,10 +127,11 @@ rslt = bmi08a_init(&dev);
 /* To Initialize gyro sensor */
 
 rslt = bmi08g_init(&dev);
+```
 
 #### Read Chip ID from the accel
 
-
+```c
 int8_t rslt;
 uint8_t data = 0;
 
@@ -139,9 +143,11 @@ if(rslt == BMI08X_OK)
     /* Read accel chip id */
     rslt = bmi08a_get_regs(BMI08X_ACCEL_CHIP_ID_REG, &data, 1, &dev);
 }
+```
 
 #### Get the accel power mode
 
+```c
 int8_t rslt;
 
 /* Initialize the device instance as per the initialization example */
@@ -151,10 +157,11 @@ int8_t rslt;
 rslt = bmi08a_get_power_mode(&dev);
 
 /* Power mode will be updated in the dev.accel_cfg.power */
-	
+```
 
 #### Get the accelerometer configurations
 
+```c
 int8_t rslt;
 
 /* Initialize the device instance as per the initialization example */
@@ -164,10 +171,11 @@ int8_t rslt;
 rslt = bmi08a_get_meas_conf(&dev);
 
 /* Config parameters will be updated in the  dev.accel_cfg.odr,dev.accel_cfg.bw and dev.accel_cfg.range */
-	
+```
 
 #### Configuring the accelerometer
 
+```c
 int8_t rslt;
 
 /* Initialize the device instance as per the initialization example */
@@ -188,11 +196,11 @@ rslt = bmi08a_set_power_mode(&dev);
 /* Wait for 10ms to switch between the power modes - delay taken care inside the function */
 
 rslt = bmi08a_set_meas_conf(&dev);
-	
+```
 
 #### Get accelerometer data
 
-
+```c
 int8_t rslt;
 struct bmi08x_sensor_data user_accel_bmi085;
 
@@ -201,10 +209,11 @@ struct bmi08x_sensor_data user_accel_bmi085;
 /* Read the sensor data into the sensor data instance */
 
 rslt = bmi08a_get_data(&user_accel_bmi085, &dev);
-
+```
 
 #### Interrupt Configuring for accel data ready interrupt
 
+```c
 /* Mapping data ready interrupt to interrupt channel */
 
 int8_t rslt;
@@ -267,10 +276,11 @@ void interrupt_handler(void)
 {
 	/* ISR functionality */
 }
-
+```
 
 #### Get the sensor time
 
+```c
 int8_t rslt;
 
 uint32_t user_sampling_time;
@@ -294,11 +304,11 @@ if(rslt == BMI08X_OK)
     /* Read gyro chip id */
     rslt = bmi08g_get_regs(BMI08X_GYRO_CHIP_ID_REG, &data, 1, &dev);
 }
-			
+```	
 
 #### Get the gyro power mode
 
-
+```c
 int8_t rslt;
 
 /* Initialize the device instance as per the initialization example */
@@ -322,10 +332,11 @@ int8_t rslt;
 rslt = bmi08g_get_meas_conf(&dev);
 
 /* Config parameters will be updated in the dev.gyro_cfg.odr,dev.gyro_cfg.bw and dev.gyro_cfg.range */
-	
+```
 
 #### Configuring the gyro
 
+```c
 int8_t rslt;
 
 /* Initialize the device instance as per the initialization example */
@@ -345,10 +356,11 @@ dev.gyro_cfg.range = BMI08X_GYRO_RANGE_1000_DPS;
 dev.gyro_cfg.bw = BMI08X_GYRO_BW_23_ODR_200_HZ;
 
 rslt = bmi08g_set_meas_conf(&dev);
-	
+```
 
 #### Get gyro data
 
+```c
 int8_t rslt;
 
 struct bmi08x_sensor_data user_gyro_bmi085;
@@ -358,10 +370,11 @@ struct bmi08x_sensor_data user_gyro_bmi085;
 /* Read the sensor data into the sensor data instance */
 
 rslt = bmi08g_get_data(&user_gyro_bmi085, &dev);
-
+```
 
 #### Interrupt Configuring for gyro data ready interrupt
 
+```c
 int8_t rslt;
 struct bmi08x_gyro_int_channel_cfg int_config;
 
@@ -410,3 +423,4 @@ int_config.int_pin_cfg.enable_int_pin = BMI08X_DISABLE;
 /* Setting the interrupt configuration */
 
 rslt = bmi08g_set_int_config(&int_config, &dev);
+```


### PR DESCRIPTION
This adds C code highlighting and proper code block formatting to the example code in the README.md. It makes it a lot nicer and easier to read.