### PR TITLE
Individual sync for xa and MM devices to set acc settings.

### DIFF
--- a/bmi08.h
+++ b/bmi08.h
@@ -501,10 +501,10 @@ int8_t bmi08a_get_sensor_time(struct bmi08_dev *dev, uint32_t *sensor_time);
  */
 
 /*!
- * \ingroup bmi08aApiSync
- * \page bmi08a_api_bmi08a_configure_data_synchronization bmi08a_configure_data_synchronization
+ * \ingroup bmi08gApiSync
+ * \page bmi08g_api_bmi08g_configure_data_synchronization bmi08g_configure_data_synchronization
  * \code
- * int8_t bmi08a_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
+ * int8_t bmi08g_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
  * \endcode
  * @details This API is used to enable/disable the data synchronization
  *  feature.
@@ -517,7 +517,7 @@ int8_t bmi08a_get_sensor_time(struct bmi08_dev *dev, uint32_t *sensor_time);
  * @retval < 0 -> Fail
  *
  */
-int8_t bmi08a_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
+int8_t bmi08g_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
 
 /**
  * \ingroup bmi08ag

--- a/bmi088_mm.h
+++ b/bmi088_mm.h
@@ -949,6 +949,70 @@ int8_t bmi088_mma_get_remap_axes(struct bmi088_mm_remap *remapped_axis, struct b
  */
 int8_t bmi088_mma_get_version_config(uint16_t *config_major, uint16_t *config_minor, struct bmi08_dev *dev);
 
+/**
+ * \ingroup bmi088_mm
+ * \defgroup bmi088_mmApiConf Read accel configurations
+ * @brief Read / Write configurations of accel sensor
+ */
+
+/*!
+ * \ingroup bmi088_mmApiConf
+ * \page bmi088_mm_api_bmi088_mm_set_meas_conf bmi088_mm_set_meas_conf
+ * \code
+ * int8_t bmi088_mm_set_meas_conf(const struct bmi08_dev *dev);
+ * \endcode
+ * @details This API sets the Output data rate, range and bandwidth
+ *  of accel sensor.
+ *  @param[in] dev  : Structure instance of bmi08_dev.
+ *
+ *  @note : The user must select one among the following macros to
+ *  select range value for BMI088_MM accel
+ *
+ *@verbatim
+ *      config                         |   value
+ *      -------------------------------|---------------------------
+ *      BMI088_MM_ACCEL_RANGE_3G       |   0x00
+ *      BMI088_MM_ACCEL_RANGE_6G       |   0x01
+ *      BMI088_MM_ACCEL_RANGE_12G      |   0x02
+ *      BMI088_MM_ACCEL_RANGE_24G      |   0x03
+ *@endverbatim
+ *
+ *  @note : Refer user guide for detailed info.
+ *
+ * @return Result of API execution status
+ * @retval 0 -> Success
+ * @retval < 0 -> Fail
+ * @retval > 0 -> Warning
+ *
+ */
+int8_t bmi088_mm_set_meas_conf(struct bmi08_dev *dev);
+
+/**
+ * \ingroup bmi088_mm
+ * \defgroup bmi088_mmApiSync Data Synchronization
+ * @brief Enable / Disable data synchronization
+ */
+
+/*!
+ * \ingroup bmi088_mmApiSync
+ * \page bmi088_mm_api_bmi088_mm_configure_data_synchronization bmi088_mm_configure_data_synchronization
+ * \code
+ * int8_t bmi088_mm_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
+ * \endcode
+ * @details This API is used to enable/disable the data synchronization
+ *  feature.
+ *
+ *  @param[in] sync_cfg : Configure sync feature
+ *  @param[in] dev : Structure instance of bmi08_dev.
+ *
+ *  @return Result of API execution status
+ *  @retval 0 -> Success
+ *  @retval < 0 -> Fail
+ *  @retval > 0 -> Warning
+ *
+ */
+int8_t bmi088_mm_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bmi08a.c
+++ b/bmi08a.c
@@ -1365,66 +1365,6 @@ int8_t bmi08a_set_fifo_down_sample(uint8_t fifo_downs, struct bmi08_dev *dev)
 }
 
 /*!
- *  @brief This API is used to enable/disable and configure the data synchronization
- *  feature.
- */
-int8_t bmi08a_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev)
-{
-    int8_t rslt;
-    uint16_t data[BMI08_ACCEL_DATA_SYNC_LEN];
-
-    /* Check for null pointer in the device structure */
-    rslt = null_ptr_check(dev);
-
-    /* Proceed if null check is fine */
-    if (rslt == BMI08_OK)
-    {
-        /* Change sensor meas config */
-        switch (sync_cfg.mode)
-        {
-            case BMI08_ACCEL_DATA_SYNC_MODE_2000HZ:
-                dev->accel_cfg.odr = BMI08_ACCEL_ODR_1600_HZ;
-                dev->accel_cfg.bw = BMI08_ACCEL_BW_NORMAL;
-                dev->gyro_cfg.odr = BMI08_GYRO_BW_230_ODR_2000_HZ;
-                dev->gyro_cfg.bw = BMI08_GYRO_BW_230_ODR_2000_HZ;
-                break;
-            case BMI08_ACCEL_DATA_SYNC_MODE_1000HZ:
-                dev->accel_cfg.odr = BMI08_ACCEL_ODR_800_HZ;
-                dev->accel_cfg.bw = BMI08_ACCEL_BW_NORMAL;
-                dev->gyro_cfg.odr = BMI08_GYRO_BW_116_ODR_1000_HZ;
-                dev->gyro_cfg.bw = BMI08_GYRO_BW_116_ODR_1000_HZ;
-                break;
-            case BMI08_ACCEL_DATA_SYNC_MODE_400HZ:
-                dev->accel_cfg.odr = BMI08_ACCEL_ODR_400_HZ;
-                dev->accel_cfg.bw = BMI08_ACCEL_BW_NORMAL;
-                dev->gyro_cfg.odr = BMI08_GYRO_BW_47_ODR_400_HZ;
-                dev->gyro_cfg.bw = BMI08_GYRO_BW_47_ODR_400_HZ;
-                break;
-            default:
-                break;
-        }
-
-        rslt = bmi08a_set_meas_conf(dev);
-
-        if (rslt == BMI08_OK)
-        {
-            rslt = bmi08g_set_meas_conf(dev);
-            if (rslt == BMI08_OK)
-            {
-                /* Enable data synchronization */
-                data[0] = (sync_cfg.mode & BMI08_ACCEL_DATA_SYNC_MODE_MASK);
-                rslt = bmi08a_write_feature_config(BMI08_ACCEL_DATA_SYNC_ADR, &data[0], BMI08_ACCEL_DATA_SYNC_LEN, dev);
-            }
-        }
-
-        /* Delay of 100ms for data sync configurations to take effect */
-        dev->delay_us(100000, dev->intf_ptr_accel);
-    }
-
-    return rslt;
-}
-
-/*!
  *  @brief This API reads the synchronized accel & gyro data from the sensor,
  *  store it in the bmi08_sensor_data structure instance
  *  passed by the user.

--- a/bmi08g.c
+++ b/bmi08g.c
@@ -1326,4 +1326,48 @@ static void unpack_gyro_data(struct bmi08_sensor_data *gyro,
     *data_index = idx;
 }
 
+/*!
+ *  @brief This API is used to enable/disable and configure the data synchronization
+ *  feature.
+ */
+int8_t bmi08g_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev)
+{
+    int8_t rslt;
+
+    /* Check for null pointer in the device structure */
+    rslt = null_ptr_check(dev);
+
+    /* Proceed if null check is fine */
+    if (rslt == BMI08_OK)
+    {
+        /* Change sensor meas config */
+        switch (sync_cfg.mode)
+        {
+            case BMI08_ACCEL_DATA_SYNC_MODE_2000HZ:
+                dev->accel_cfg.odr = BMI08_ACCEL_ODR_1600_HZ;
+                dev->accel_cfg.bw = BMI08_ACCEL_BW_NORMAL;
+                dev->gyro_cfg.odr = BMI08_GYRO_BW_230_ODR_2000_HZ;
+                dev->gyro_cfg.bw = BMI08_GYRO_BW_230_ODR_2000_HZ;
+                break;
+            case BMI08_ACCEL_DATA_SYNC_MODE_1000HZ:
+                dev->accel_cfg.odr = BMI08_ACCEL_ODR_800_HZ;
+                dev->accel_cfg.bw = BMI08_ACCEL_BW_NORMAL;
+                dev->gyro_cfg.odr = BMI08_GYRO_BW_116_ODR_1000_HZ;
+                dev->gyro_cfg.bw = BMI08_GYRO_BW_116_ODR_1000_HZ;
+                break;
+            case BMI08_ACCEL_DATA_SYNC_MODE_400HZ:
+                dev->accel_cfg.odr = BMI08_ACCEL_ODR_400_HZ;
+                dev->accel_cfg.bw = BMI08_ACCEL_BW_NORMAL;
+                dev->gyro_cfg.odr = BMI08_GYRO_BW_47_ODR_400_HZ;
+                dev->gyro_cfg.bw = BMI08_GYRO_BW_47_ODR_400_HZ;
+                break;
+            default:
+                break;
+        }
+
+        rslt = bmi08g_set_meas_conf(dev);
+    }
+    return rslt;
+}
+
 /*! @endcond */

--- a/bmi08x.h
+++ b/bmi08x.h
@@ -180,6 +180,32 @@ int8_t bmi08xa_set_meas_conf(struct bmi08_dev *dev);
  */
 int8_t bmi08xa_perform_selftest(struct bmi08_dev *dev);
 
+/**
+ * \ingroup bmi08xag
+ * \defgroup bmi08xaApiSync Data Synchronization
+ * @brief Enable / Disable data synchronization
+ */
+
+/*!
+ * \ingroup bmi08xaApiSync
+ * \page bmi08xa_api_bmi08xa_configure_data_synchronization bmi08xa_configure_data_synchronization
+ * \code
+ * int8_t bmi08xa_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
+ * \endcode
+ * @details This API is used to enable/disable the data synchronization
+ *  feature.
+ *
+ *  @param[in] sync_cfg : Configure sync feature
+ *  @param[in] dev : Structure instance of bmi08_dev.
+ *
+ *  @return Result of API execution status
+ *  @retval 0 -> Success
+ *  @retval < 0 -> Fail
+ *  @retval > 0 -> Warning
+ *
+ */
+int8_t bmi08xa_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bmi08xa.c
+++ b/bmi08xa.c
@@ -809,4 +809,35 @@ static int8_t validate_accel_self_test(const struct bmi08_sensor_data *accel_pos
     return rslt;
 }
 
+/*!
+ *  @brief This API is used to enable/disable and configure the data synchronization
+ *  feature.
+ */
+int8_t bmi08xa_configure_data_synchronization(struct bmi08_data_sync_cfg sync_cfg, struct bmi08_dev *dev) 
+{
+    int8_t rslt;
+    uint16_t data[BMI08_ACCEL_DATA_SYNC_LEN];
+
+    /* Set device configuration and gyro registers. */
+    rslt = bmi08g_configure_data_synchronization(sync_cfg, dev);
+
+    /* Proceed if gyro setting is fine */
+    if (rslt == BMI08_OK)
+    {
+        rslt = bmi08xa_set_meas_conf(dev);
+
+        if (rslt == BMI08_OK)
+        {
+            /* Enable data synchronization */
+            data[0] = (sync_cfg.mode & BMI08_ACCEL_DATA_SYNC_MODE_MASK);
+            rslt = bmi08a_write_feature_config(BMI08_ACCEL_DATA_SYNC_ADR, &data[0], BMI08_ACCEL_DATA_SYNC_LEN, dev);
+        }
+
+        /* Delay of 100ms for data sync configurations to take effect */
+        dev->delay_us(100000, dev->intf_ptr_accel);
+    }
+
+    return rslt;
+}
+
 /*! @endcond */

--- a/examples/bmi088_mm/data_sync_mcu/data_sync_mcu.c
+++ b/examples/bmi088_mm/data_sync_mcu/data_sync_mcu.c
@@ -112,7 +112,7 @@ static void init_bmi08(struct bmi08_dev *bmi08dev)
 
             /*! Mode (0 = off, 1 = 400Hz, 2 = 1kHz, 3 = 2kHz) */
             sync_cfg.mode = BMI08_ACCEL_DATA_SYNC_MODE_400HZ;
-            rslt = bmi08a_configure_data_synchronization(sync_cfg, bmi08dev);
+            rslt = bmi088_mm_configure_data_synchronization(sync_cfg, bmi08dev);
         }
     }
 
@@ -209,7 +209,7 @@ static void disable_bmi08_data_synchronization_interrupt(struct bmi08_dev *bmi08
 
     sync_cfg.mode = BMI08_ACCEL_DATA_SYNC_MODE_OFF; /*turn off the sync feature*/
 
-    rslt = bmi08a_configure_data_synchronization(sync_cfg, bmi08dev);
+    rslt = bmi088_mm_configure_data_synchronization(sync_cfg, bmi08dev);
 
     /* Wait for 150ms to enable the data synchronization --delay taken care inside the function */
     /* configure synchronization interrupt pins */

--- a/examples/bmi08x/read_synchronized_data_mcu/read_synchronized_data_mcu.c
+++ b/examples/bmi08x/read_synchronized_data_mcu/read_synchronized_data_mcu.c
@@ -158,8 +158,8 @@ static int8_t init_bmi08(void)
                 /* Mode (0 = off, 1 = 400Hz, 2 = 1kHz, 3 = 2kHz) */
                 sync_cfg.mode = BMI08_ACCEL_DATA_SYNC_MODE_400HZ;
 
-                rslt = bmi08a_configure_data_synchronization(sync_cfg, &bmi08dev);
-                bmi08_error_codes_print_result("bmi08a_configure_data_synchronization", rslt);
+                rslt = bmi08xa_configure_data_synchronization(sync_cfg, &bmi08dev);
+                bmi08_error_codes_print_result("bmi08xa_configure_data_synchronization", rslt);
             }
 
             if (rslt == BMI08_OK)
@@ -252,8 +252,8 @@ static int8_t disable_bmi08_data_synchronization_interrupt()
     /*turn off the sync feature*/
     sync_cfg.mode = BMI08_ACCEL_DATA_SYNC_MODE_OFF;
 
-    rslt = bmi08a_configure_data_synchronization(sync_cfg, &bmi08dev);
-    bmi08_error_codes_print_result("bmi08a_configure_data_synchronization", rslt);
+    rslt = bmi08xa_configure_data_synchronization(sync_cfg, &bmi08dev);
+    bmi08_error_codes_print_result("bmi08xa_configure_data_synchronization", rslt);
 
     /* Wait for 150ms to enable the data synchronization --delay taken care inside the function */
     /* configure synchronization interrupt pins */


### PR DESCRIPTION
I don't know if this was intended, but `bmi08a_configure_data_synchronization` changed `dev->accel_cfg.odr` and `dev->accel_cfg.bw` but did not set `BMI08_REG_ACCEL_CONF` on the IMU. This PR implements individual `bmi08xa_configure_data_synchronization` and `bmi088_mm_configure_data_synchronization` that actually set the accelerometer config.

`bmi08xa_configure_data_synchronization` sets the register now. `bmi088_mm_configure_data_synchronization` I could not test.