### PR TITLE
Fix BMI08_ACCEL_BW_MASK

### DIFF
--- a/bmi08_defs.h
+++ b/bmi08_defs.h
@@ -282,7 +282,7 @@
 
 /**\name    Mask definitions for odr, bandwidth and range */
 #define BMI08_ACCEL_ODR_MASK                    UINT8_C(0x0F)
-#define BMI08_ACCEL_BW_MASK                     UINT8_C(0xF0)
+#define BMI08_ACCEL_BW_MASK                     UINT8_C(0x70)
 #define BMI08_ACCEL_RANGE_MASK                  UINT8_C(0x03)
 
 /**\name    Position definitions for odr, bandwidth and range */


### PR DESCRIPTION
According to data sheet the BW mask is only bit `[6:4]` not `[7:4]`.